### PR TITLE
Bump gradle-build-action to v2.3.3

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,6 +25,6 @@ jobs:
         java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@v2.1.5
+      uses: gradle/gradle-build-action@v2.3.3
       with:
         arguments: build


### PR DESCRIPTION
Fixes deprecation warnings from GitHub.
