### PR TITLE
Add missing Lucene99 codec and relax term vectors constraint whem merging

### DIFF
--- a/src/main/java/org/trypticon/luceneupgrader/lucene9/internal/lucene/index/FieldInfos.java
+++ b/src/main/java/org/trypticon/luceneupgrader/lucene9/internal/lucene/index/FieldInfos.java
@@ -440,7 +440,12 @@ public class FieldInfos implements Iterable<FieldInfo> {
       this.omitNorms = new HashMap<>();
       this.storeTermVectors = new HashMap<>();
       this.softDeletesFieldName = softDeletesFieldName;
-      this.strictlyConsistent = indexCreatedVersionMajor >= 9;
+
+      // Don't perform "strictly consistent" checking as Lucene 8/9 semantics differ.  Lucene 8 sets "term vectors" to false
+      // even if a field was declared to use "term vectors", but it emitted no terms in the entire segment.
+      // Lucene 9 seems to rely on the declared field.  Disabling this check to avoid these headaches.
+      this.strictlyConsistent = false;
+      // this.strictlyConsistent = indexCreatedVersionMajor >= 9;
       this.parentFieldName = parentFieldName;
       if (softDeletesFieldName != null
           && parentFieldName != null

--- a/src/main/resources/META-INF/services/org.trypticon.luceneupgrader.lucene9.internal.lucene.codecs.Codec
+++ b/src/main/resources/META-INF/services/org.trypticon.luceneupgrader.lucene9.internal.lucene.codecs.Codec
@@ -15,6 +15,7 @@
 
 org.trypticon.luceneupgrader.lucene9.internal.lucene.codecs.lucene912.Lucene912Codec
 
+org.trypticon.luceneupgrader.lucene9.internal.lucene.backward_codecs.lucene99.Lucene99Codec
 org.trypticon.luceneupgrader.lucene9.internal.lucene.backward_codecs.lucene95.Lucene95Codec
 org.trypticon.luceneupgrader.lucene9.internal.lucene.backward_codecs.lucene80.Lucene80Codec
 org.trypticon.luceneupgrader.lucene9.internal.lucene.backward_codecs.lucene84.Lucene84Codec

--- a/src/main/resources/META-INF/services/org.trypticon.luceneupgrader.lucene9.internal.lucene.codecs.PostingsFormat
+++ b/src/main/resources/META-INF/services/org.trypticon.luceneupgrader.lucene9.internal.lucene.codecs.PostingsFormat
@@ -15,6 +15,7 @@
 
 org.trypticon.luceneupgrader.lucene9.internal.lucene.codecs.lucene912.Lucene912PostingsFormat
 
+org.trypticon.luceneupgrader.lucene9.internal.lucene.backward_codecs.lucene99.Lucene99PostingsFormat
 org.trypticon.luceneupgrader.lucene9.internal.lucene.backward_codecs.lucene90.Lucene90PostingsFormat
 org.trypticon.luceneupgrader.lucene9.internal.lucene.backward_codecs.lucene84.Lucene84PostingsFormat
 org.trypticon.luceneupgrader.lucene9.internal.lucene.backward_codecs.lucene50.Lucene50PostingsFormat


### PR DESCRIPTION
It seems in Lucene 8.x and earlier, a field with "term vectors" enabled but with no actual terms emitted, will set "term vectors" to false for that field, but in Lucene 9 it respects the field definition regardless of terms emitted.  I relaxed the strictness check introduced in Lucene 9 otherwise some migrations may fail for an index which has multiple segments created in different versions.

